### PR TITLE
fix(build): autorelease should handle tagging

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,2 @@
 releaseType: node
-handleGHRelease: true
+


### PR DESCRIPTION
allow autorelease to handle tagging, so that it can kick off doc publication.